### PR TITLE
Validate Refresh Token Expiration

### DIFF
--- a/src/api/models/user.model.js
+++ b/src/api/models/user.model.js
@@ -52,8 +52,8 @@ const userSchema = new mongoose.Schema({
     trim: true,
   },
 }, {
-  timestamps: true,
-});
+    timestamps: true,
+  });
 
 /**
  * Add your
@@ -159,7 +159,11 @@ userSchema.statics = {
       }
       err.message = 'Incorrect email or password';
     } else if (refreshObject && refreshObject.userEmail === email) {
-      return { user, accessToken: user.token() };
+      if (moment(refreshObject.expires).isBefore()) {
+        err.message = 'Invalid refresh token.';
+      } else {
+        return { user, accessToken: user.token() };
+      }
     } else {
       err.message = 'Incorrect email or refreshToken';
     }


### PR DESCRIPTION
Checking refresh token for expiration before issuing a new one.

If invalid, return unauthorized, otherwise continue.