### PR TITLE
fix format in docker-compose.test.yml

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,5 +2,5 @@ version: "2"
 services:
   boilerplate-api:
     command: yarn test
-  environment:
-    - NODE_ENV=test
+    environment:
+      - NODE_ENV=test


### PR DESCRIPTION
Running `yarn docker:test` I got the following error:

```shell
yarn docker:test
yarn run v1.9.4
$ docker-compose -f docker-compose.yml -f docker-compose.test.yml up --abort-on-container-exit
ERROR: In file './docker-compose.test.yml', service 'environment' must be a mapping not an array.
error Command failed with exit code 1.
```
because of the wrong format in `docker-compose.test.yml`

here the fix
