### PR TITLE
Update docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,5 +2,5 @@ version: "2"
 services:
   boilerplate-api:
     command: yarn dev -- -L
-  environment:
-    - NODE_ENV=development
+    environment:
+      - NODE_ENV=development


### PR DESCRIPTION
Wrong indentation causes error
> ERROR: In file '.\docker-compose.dev.yml', service 'environment' must be a mapping not an array.