### PR TITLE
Fixing misuse of useMongoClient and deprecated url parser.

### DIFF
--- a/src/config/mongoose.js
+++ b/src/config/mongoose.js
@@ -24,7 +24,7 @@ if (env === 'development') {
 exports.connect = () => {
   mongoose.connect(mongo.uri, {
     keepAlive: 1,
-    useMongoClient: true,
+    useNewUrlParser: true,
   });
   return mongoose.connection;
 };


### PR DESCRIPTION
WARNING: The `useMongoClient` option is no longer necessary in mongoose 5.x, please remove it.

DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
