### PR TITLE
Password reset successful when token is expired

### DIFF
--- a/src/api/controllers/auth.controller.js
+++ b/src/api/controllers/auth.controller.js
@@ -128,7 +128,7 @@ exports.resetPassword = async (req, res, next) => {
       err.message = 'Cannot find matching reset token';
       throw new APIError(err);
     }
-    if (moment().isAfter(resetTokenObject.expires)) {
+    if (moment(resetTokenObject.expires).isAfter(moment.now())) {
       err.message = 'Reset token is expired';
       throw new APIError(err);
     }


### PR DESCRIPTION
I realized that the app permitted a successful password reset after using an expired reset token which is 2 days behind time.
This is because for every expired reset token the condition  on line 131 will always be true since moment will default to the current date  if no argument is  provided. So the solution is to provide the moment with the expired token date and then use the current date as the benchmark since we are using ``` .isAfter() ``` method. 
Thanks